### PR TITLE
Turn off pylint checks for import errors on specific lines

### DIFF
--- a/actions/ec2_wait_for_state.py
+++ b/actions/ec2_wait_for_state.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from actions.lib import action
+from actions.lib import action  # pylint: disable=import-error
 
 
 class WaitManager(action.BaseAction):

--- a/actions/run.py
+++ b/actions/run.py
@@ -2,7 +2,7 @@
 ST2 AWS pack action runner script
 '''
 
-from actions.lib import action
+from actions.lib import action  # pylint: disable=import-error
 
 
 class ActionManager(action.BaseAction):


### PR DESCRIPTION
I fixed pack CI so it wouldn't generate a huge string too large to interpolate and reran the CI jobs for your PR StackStorm-Exchange/stackstorm-aws#89, but the Python 2 Python lint checks still failed because pylint couldn't figure out where `actions.lib` was located.

This PR turns off that pylint check in the two places that it fails.